### PR TITLE
Load API keys from .env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in the required values
+
+# YouTube Data API key
+YT_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+.env

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Install dependencies (from `requirements.txt`):
 pip install -r requirements.txt
 ```
 
+Copy the environment template and add your API key:
+
+```bash
+cp .env.template .env
+# then edit .env and set YT_API_KEY
+```
+
 ---
 
 ## 🔑 API Key Setup
@@ -50,8 +57,9 @@ pip install -r requirements.txt
 2. Create a new project (if needed).
 3. Enable the **YouTube Data API v3**.
 4. Create an **API key**.
-5. Either:
-   - Export it as an environment variable:
+5. Make it available to the script:
+   - Copy `.env.template` to `.env` and set `YT_API_KEY=YOUR_API_KEY`
+   - Or export it as an environment variable:
      ```bash
      export YT_API_KEY="YOUR_API_KEY"
      ```
@@ -71,7 +79,10 @@ python youtube_channel_to_rss.py --channel <CHANNEL> [options]
 # Using a custom URL
 python youtube_channel_to_rss.py --channel "https://www.youtube.com/c/thisoldtony" --api-key YOUR_KEY --out thisoldtony.rss
 
-# Using a handle with env var
+# Using a handle with API key from .env
+python youtube_channel_to_rss.py --channel @thisoldtony --out feed.rss
+
+# Using a handle with an exported env var
 export YT_API_KEY=YOUR_KEY
 python youtube_channel_to_rss.py --channel @thisoldtony --out feed.rss
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ charset-normalizer==3.4.3
 idna==3.10
 requests==2.32.5
 urllib3==2.5.0
+python-dotenv==1.0.1

--- a/youtube_channel_to_rss.py
+++ b/youtube_channel_to_rss.py
@@ -32,6 +32,9 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
 


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file
- provide `.env.template` and ignore user-specific `.env`
- document configuration of API key via `.env`

## Testing
- `python -m py_compile youtube_channel_to_rss.py`
- `python youtube_channel_to_rss.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement certifi==2025.8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c89ccf70c8832c8c393f8429c188db