### PR TITLE
Default feed to newest-first and add generated caption option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It uses the [YouTube Data API v3](https://developers.google.com/youtube/v3) to f
   - **Views** and **likes** (if available)
   - **Thumbnails** (via `<media:thumbnail>`)
   - `<media:content>` entries with duration metadata
+  - Optional **captions/transcripts** (manual or opt-in auto-generated) embedded in `<description>` and `<media:subtitle>`
 - Channel metadata:
   - Channel title, description, publish date
   - Subscriber/video/view counts (as comments)
@@ -86,18 +87,30 @@ python youtube_channel_to_rss.py --channel @thisoldtony --out feed.rss
 export YT_API_KEY=YOUR_KEY
 python youtube_channel_to_rss.py --channel @thisoldtony --out feed.rss
 
-# Using a raw channel ID, newest-first
-python youtube_channel_to_rss.py --channel UCxxxxxxx --descending --out latest.rss
+# Using a raw channel ID (newest videos come first by default)
+python youtube_channel_to_rss.py --channel UCxxxxxxx --out latest.rss
+
+# Flipping the feed to oldest-first order
+python youtube_channel_to_rss.py --channel UCxxxxxxx --oldest-first --out archive.rss
+
+# Including English captions in the feed
+python youtube_channel_to_rss.py --channel UCxxxxxxx --include-captions --caption-language en --out captions.rss
+
+# Including captions with auto-generated fallback
+python youtube_channel_to_rss.py --channel UCxxxxxxx --include-captions --allow-generated-captions --out captions.rss
 ```
 
 ### Arguments
 
-| Option         | Description                                                                 |
-|----------------|-----------------------------------------------------------------------------|
-| `--channel`    | Channel URL, @handle, /channel/ID, /user/NAME, /c/NAME, or search query     |
-| `--api-key`    | YouTube API key (or set `YT_API_KEY` env var)                               |
-| `--out`        | Output file path (default: `stdout`)                                        |
-| `--descending` | Sort newest-first (default is oldest-first)                                 |
+| Option               | Description                                                                 |
+|----------------------|-----------------------------------------------------------------------------|
+| `--channel`          | Channel URL, @handle, /channel/ID, /user/NAME, /c/NAME, or search query     |
+| `--api-key`          | YouTube API key (or set `YT_API_KEY` env var)                               |
+| `--out`              | Output file path (default: `stdout`)                                        |
+| `--oldest-first`     | Sort the feed so the oldest uploads appear first (default is newest-first)  |
+| `--include-captions` | Fetch and embed captions/transcripts for each video                         |
+| `--caption-language` | Preferred caption language code (default: `en`; used with `--include-captions`) |
+| `--allow-generated-captions` | Permit falling back to YouTube's auto-generated captions (used with `--include-captions`) |
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ idna==3.10
 requests==2.32.5
 urllib3==2.5.0
 python-dotenv==1.0.1
+youtube-transcript-api

--- a/youtube_channel_to_rss.py
+++ b/youtube_channel_to_rss.py
@@ -33,6 +33,7 @@ from typing import Dict, List, Optional, Tuple
 
 import requests
 from dotenv import load_dotenv
+from youtube_transcript_api import NoTranscriptFound, TranscriptsDisabled, YouTubeTranscriptApi
 
 load_dotenv()
 
@@ -85,6 +86,81 @@ def pick_best_thumb(thumbs: Dict) -> Tuple[str, int, int]:
             return (t.get("url", ""), t.get("width", 0), t.get("height", 0))
     k, t = next(iter(thumbs.items()))
     return (t.get("url", ""), t.get("width", 0), t.get("height", 0))
+
+def fetch_captions(video_id: str, lang: str = "en", allow_generated: bool = False) -> str:
+    """Fetch captions for a video in the preferred language, if available."""
+    languages = [lang]
+    normalized = lang.lower()
+    fallback_candidates = []
+    if normalized not in {"en", "en-us"}:
+        fallback_candidates.extend(["en", "en-US"])
+    seen = {normalized}
+    for candidate in fallback_candidates:
+        if candidate.lower() not in seen:
+            languages.append(candidate)
+            seen.add(candidate.lower())
+
+    try:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    except (TranscriptsDisabled, NoTranscriptFound):
+        return ""
+    except Exception:
+        return ""
+
+    transcript_entries: Optional[List[Dict]] = None
+
+    manual_transcript = None
+    try:
+        manual_transcript = transcript_list.find_manually_created_transcript(languages)
+    except AttributeError:
+        try:
+            candidate = transcript_list.find_transcript(languages)
+            if not getattr(candidate, "is_generated", False):
+                manual_transcript = candidate
+        except NoTranscriptFound:
+            manual_transcript = None
+    except NoTranscriptFound:
+        manual_transcript = None
+
+    if manual_transcript is not None:
+        try:
+            transcript_entries = manual_transcript.fetch()
+        except Exception:
+            transcript_entries = None
+
+    if transcript_entries is None and allow_generated:
+        try:
+            generated_transcript = transcript_list.find_generated_transcript(languages)
+        except AttributeError:
+            generated_transcript = None
+        except NoTranscriptFound:
+            generated_transcript = None
+
+        if generated_transcript is not None:
+            try:
+                transcript_entries = generated_transcript.fetch()
+            except Exception:
+                transcript_entries = None
+
+        if transcript_entries is None:
+            for transcript in transcript_list:
+                try:
+                    if getattr(transcript, "is_generated", False):
+                        transcript_entries = transcript.fetch()
+                        if transcript_entries:
+                            break
+                except Exception:
+                    continue
+
+    if not transcript_entries:
+        return ""
+
+    lines: List[str] = []
+    for entry in transcript_entries:
+        text = entry.get("text", "").strip()
+        if text:
+            lines.append(text.replace("\n", " "))
+    return " ".join(lines).strip()
 
 # --- API Calls ----------------------------------------------------------------
 
@@ -249,7 +325,7 @@ def fetch_video_details(session: requests.Session, api_key: str, video_ids: List
         })
         videos.extend(data.get("items", []))
         time.sleep(0.05)
-    videos.sort(key=lambda v: v["snippet"].get("publishedAt", ""))
+    videos.sort(key=lambda v: v["snippet"].get("publishedAt", ""), reverse=True)
     return videos
 
 # --- RSS generation -----------------------------------------------------------
@@ -330,7 +406,14 @@ def build_rss(channel: Dict, videos: List[Dict], channel_url: Optional[str]=None
 
         meta_html = "<br/>".join(html.escape(bit, quote=False) for bit in meta_bits)
         desc_html = f"{meta_html}<br/><br/>{html.escape(vdesc or '', quote=False)}"
+        captions_text = v.get("captions")
+        caption_html = None
+        if captions_text:
+            caption_html = html.escape(captions_text, quote=False).replace("\n", "<br/>")
+            desc_html = f"{desc_html}<br/><br/><strong>Captions:</strong><br/>{caption_html}"
         rss.append(f"<description>{desc_html}</description>")
+        if caption_html:
+            rss.append(f"<media:subtitle>{caption_html}</media:subtitle>")
 
         if turl:
             rss.append(f'<media:thumbnail url="{html.escape(turl, quote=True)}" width="{tw}" height="{th}"/>')
@@ -349,7 +432,22 @@ def main():
     parser.add_argument("--channel", required=True, help="Channel URL (@handle, /channel/ID, /user/NAME, /c/NAME), channel ID, or search query")
     parser.add_argument("--api-key", default=os.environ.get("YT_API_KEY"), help="YouTube Data API v3 key (or set YT_API_KEY)")
     parser.add_argument("--out", default="-", help="Output RSS file path (default: stdout)")
-    parser.add_argument("--descending", action="store_true", help="Sort newest first (default is oldest first)")
+    parser.add_argument(
+        "--oldest-first",
+        action="store_true",
+        help="Sort the RSS feed with the oldest uploads first (default: newest first)",
+    )
+    parser.add_argument("--include-captions", action="store_true", help="Include video captions/transcripts in the RSS feed")
+    parser.add_argument(
+        "--caption-language",
+        default="en",
+        help="Preferred caption language code when including captions (default: en)",
+    )
+    parser.add_argument(
+        "--allow-generated-captions",
+        action="store_true",
+        help="Allow falling back to auto-generated captions when fetching transcripts",
+    )
     args = parser.parse_args()
 
     if not args.api_key:
@@ -363,7 +461,17 @@ def main():
         uploads_pid = get_uploads_playlist_id(channel_resource)
         video_ids = fetch_all_playlist_video_ids(session, args.api_key, uploads_pid)
         videos = fetch_video_details(session, args.api_key, video_ids)
-        if args.descending:
+        if args.include_captions:
+            preferred_lang = (args.caption_language or "en").strip() or "en"
+            for video in videos:
+                caption_text = fetch_captions(
+                    video["id"],
+                    lang=preferred_lang,
+                    allow_generated=args.allow_generated_captions,
+                )
+                if caption_text:
+                    video["captions"] = caption_text
+        if args.oldest_first:
             videos = list(reversed(videos))
         rss_xml = build_rss(channel_resource, videos, channel_url=args.channel if args.channel.startswith("http") or args.channel.startswith("@") else None)
     except requests.HTTPError as e:


### PR DESCRIPTION
## Summary
- sort fetched videos in descending publish order by default and expose --oldest-first to restore chronological output
- extend caption fetching to prefer manual transcripts while optionally falling back to auto-generated captions when requested
- document the new defaults and CLI switches for ordering and generated captions in the README

## Testing
- python -m compileall youtube_channel_to_rss.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a24b0960832cbcbb89e30916a61e